### PR TITLE
Fix tariff zone methods names in Point

### DIFF
--- a/Models/Point.php
+++ b/Models/Point.php
@@ -384,7 +384,7 @@ class Point extends  ShortPoint
     /**
      * @return mixed
      */
-    public function getTarrifZone()
+    public function getTariffZone()
     {
         return $this->tarrifZone;
     }
@@ -392,7 +392,7 @@ class Point extends  ShortPoint
     /**
      * @param mixed $tarrifZone
      */
-    public function setTarrifZone($tarrifZone)
+    public function setTariffZone($tarrifZone)
     {
         $this->tarrifZone = $tarrifZone;
     }


### PR DESCRIPTION
There's a typo in tariff method names Point::setTarriffZone() and Point::getTarriffZone() (`tarriff` should be `trariff`). This prevents AbstractModel to set tariffZone property as there's no Point::setTariffZone() method. In result calls to API methods like 'ListPoints' results in Point::tariffZone being not set, i.e. null.