### PR TITLE
Bugfix: POST requests were used for GET methods

### DIFF
--- a/Client/Client.php
+++ b/Client/Client.php
@@ -331,7 +331,7 @@ class Client
 				HTTP::setCacheTimeLife(0);
 			}
             $data = array_merge($data, $serializer->toArray($request));
-            $answer = HTTP::post($this->api_url, $data)->getAnswer();
+            $answer = HTTP::get($this->api_url, $data)->getAnswer();
 
         }
         unset($serializer);


### PR DESCRIPTION
It seems that POST requests are incorrectly used for GET methods. It may have worked in the past, but it's not guaranteed to work in the future.